### PR TITLE
optimize artworkcard animation and add greek key svg logo

### DIFF
--- a/PAMS/Components/ArtworkCard.swift
+++ b/PAMS/Components/ArtworkCard.swift
@@ -3,16 +3,17 @@ import SwiftUI
 struct ArtworkCard<Front: View, Back: View>: View {
     let front: Front
     let back: Back
-
+    
     let cornerRadius: CGFloat
     let strokeWidth: CGFloat
     let innerPadding: CGFloat
     let outerPadding: CGFloat
     let innerAnimationSpeed: Double
-
-    @Environment(\.colorScheme) private var colorScheme
-    @State private var rotation: Double = 0
-
+    let isFocused: Bool
+    
+    @Environment(\.colorScheme) var colorScheme
+    @State var rotation: Double = 0
+    
     init(
         cornerRadius: CGFloat = 32,
         strokeWidth: CGFloat = 1,
@@ -20,6 +21,7 @@ struct ArtworkCard<Front: View, Back: View>: View {
         outerPadding: CGFloat = 14,
         innerAnimationSpeed: Double = 12,
         outerAnimationSpeed: Double = 18,
+        isFocused: Bool = true,
         @ViewBuilder front: () -> Front,
         @ViewBuilder back: () -> Back
     ) {
@@ -28,17 +30,16 @@ struct ArtworkCard<Front: View, Back: View>: View {
         self.innerPadding = innerPadding
         self.outerPadding = outerPadding
         self.innerAnimationSpeed = innerAnimationSpeed
+        self.isFocused = isFocused
         self.front = front()
         self.back = back()
     }
-
     
-    private var isFaceUp: Bool {
+    var isFaceUp: Bool {
         let degrees = rotation.truncatingRemainder(dividingBy: 360)
-        
         return (degrees >= 0 && degrees < 90) || (degrees >= 270 && degrees < 360)
     }
-
+    
     var body: some View {
         ZStack {
             cardFront
@@ -53,19 +54,19 @@ struct ArtworkCard<Front: View, Back: View>: View {
         .sensoryFeedback(.impact(weight: .light), trigger: rotation)
     }
     
-    private var cardFront: some View {
+    var cardFront: some View {
         cardBody(front)
             .opacity(isFaceUp ? 1 : 0)
     }
     
-    private var cardBack: some View {
+    var cardBack: some View {
         cardBody(back)
             .opacity(isFaceUp ? 0 : 1)
             .rotation3DEffect(.degrees(180), axis: (x: 0, y: 1, z: 0))
             .drawingGroup()
     }
-
-    private func cardBody(_ v: some View) -> some View {
+    
+    func cardBody(_ v: some View) -> some View {
         v
             .clipShape(RoundedRectangle(cornerRadius: cornerRadius, style: .continuous))
             .shadow(color: .primary.opacity(colorScheme == .light ? 0.2 : 0), radius: 5, x: 0, y: 5)
@@ -76,44 +77,77 @@ struct ArtworkCard<Front: View, Back: View>: View {
                     strokeWidth: strokeWidth,
                     strokeColor: colorScheme == .dark ? .white : .black,
                     clockwise: true,
-                    speed: innerAnimationSpeed
+                    speed: innerAnimationSpeed,
+                    isFocused: isFocused
                 )
             }
             .padding(outerPadding)
     }
 }
 
-private struct AnimatedBorder: View {
+struct AnimatedBorder: View {
     let cornerRadius: CGFloat
     let strokeWidth: CGFloat
     let strokeColor: Color
     let clockwise: Bool
     let speed: Double
-
-    @State private var rotation: CGFloat = 0
-
+    let isFocused: Bool
+    
+    @State var phase: CGFloat = 0
+    
     var body: some View {
-        GeometryReader { _ in
+        GeometryReader { geometry in
             let shape = RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
-            let strokeLength: CGFloat = 0.09
-
+            let width = geometry.size.width
+            let height = geometry.size.height
+            
+            let straightParts = 2 * (width + height)
+            let cornerAdjustment = (2 * CGFloat.pi - 8) * cornerRadius
+            let perimeter = straightParts + cornerAdjustment
+            
+            let strokeLength = perimeter * 0.15
+            
             shape
-                .trim(from: rotation, to: rotation + strokeLength)
-                .stroke(strokeColor.opacity(0.9), style: StrokeStyle(lineWidth: strokeWidth, lineCap: .round))
-                .onAppear {
-                    withAnimation(.easeIn(duration: speed).repeatForever()) {
-                        rotation = clockwise ? 1.0 : -1.0
+                .stroke(
+                    strokeColor.opacity(isFocused ? 0.9 : 0),
+                    style: StrokeStyle(
+                        lineWidth: strokeWidth,
+                        lineCap: .round,
+                        dash: [strokeLength, perimeter - strokeLength],
+                        dashPhase: phase
+                    )
+                )
+                .animation(.easeInOut(duration: 0.8), value: isFocused)
+                .task(id: isFocused) {
+                    if isFocused {
+                        startAnimation(perimeter: perimeter)
+                    } else {
+                        try? await Task.sleep(nanoseconds: 800_000_000)
+                        if !Task.isCancelled {
+                            stopAnimation()
+                        }
                     }
                 }
         }
         .allowsHitTesting(false)
+    }
+    
+    func startAnimation(perimeter: CGFloat) {
+        withAnimation(.linear(duration: speed).repeatForever(autoreverses: false)) {
+            phase = clockwise ? -perimeter : perimeter
+        }
+    }
+    
+    func stopAnimation() {
+        withAnimation(.default) {
+            phase = 0
+        }
     }
 }
 
 struct FlippableArtworkCard_Previews: PreviewProvider {
     static var previews: some View {
         ArtworkCard {
-            
             Image(systemName: "music.note")
                 .resizable()
                 .scaledToFit()
@@ -121,7 +155,6 @@ struct FlippableArtworkCard_Previews: PreviewProvider {
                 .foregroundColor(.purple)
                 .background(Color(.systemGray6))
         } back: {
-            
             VStack(spacing: 6) {
                 Text("Song Name")
                     .font(.headline)

--- a/PAMS/Resources/pamslogo.svg
+++ b/PAMS/Resources/pamslogo.svg
@@ -1,0 +1,3 @@
+<svg width="100" height="100" viewBox="-4 -4 108 108" xmlns="http://www.w3.org/2000/svg">
+    <path d="M0 75 L0 0 L100 0 L100 100 L17 100 L17 25 L79 25 L79 80 L33 80 L33 44 L62.5 44 L62.5 65 L48 65 L48 56" fill="none" stroke="black" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/PAMS/Utils/VisibilityPreferenceKey.swift
+++ b/PAMS/Utils/VisibilityPreferenceKey.swift
@@ -1,0 +1,9 @@
+import SwiftUI
+
+struct VisibilityPreferenceKey: PreferenceKey {
+    static var defaultValue: [String: Double] = [:]
+
+    static func reduce(value: inout [String: Double], nextValue: () -> [String: Double]) {
+        value.merge(nextValue()) { _, new in new }
+    }
+}

--- a/PAMS/Views/ResultsListView.swift
+++ b/PAMS/Views/ResultsListView.swift
@@ -3,34 +3,15 @@ import SwiftUI
 struct ResultsListView: View {
     let results: [SearchResult]
     let isLoading: Bool
+    
+    @State var focusedID: String? = nil
 
     var body: some View {
         ZStack {
             if results.isEmpty && !isLoading {
-                Text("Find your music across platforms")
-                    .foregroundStyle(.secondary)
-                    .italic()
-                    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .center)
+                emptyStateView
             } else {
-                GeometryReader { geometry in
-                    ScrollView {
-                        LazyVStack(spacing: 20) {
-                            ForEach(results) { result in
-                                SearchResultRow(
-                                    result: result,
-                                    iconSpotifyBlack: "spotify_icon_black",
-                                    iconSpotifyWhite: "spotify_icon_white",
-                                    iconTidalBlack: "tidal_icon_black",
-                                    iconTidalWhite: "tidal_icon_white",
-                                    iconYTWhite: "yt_icon_white",
-                                    iconYTBlack: "yt_icon_black"
-                                )
-                            }
-                        }
-                        .frame(minHeight: geometry.size.height)
-                        .frame(maxWidth: .infinity)
-                    }
-                }
+                resultsList
             }
         }
         .background(Color(UIColor.systemBackground))
@@ -38,6 +19,61 @@ struct ResultsListView: View {
             Rectangle()
                 .fill(.ultraThinMaterial)
                 .ignoresSafeArea()
+        }
+        .onPreferenceChange(VisibilityPreferenceKey.self) { preferences in
+            updateFocus(with: preferences)
+        }
+    }
+    
+    var emptyStateView: some View {
+        Text("Find your music across platforms")
+            .foregroundStyle(.secondary)
+            .italic()
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .center)
+    }
+    
+    var resultsList: some View {
+        GeometryReader { geometry in
+            ScrollView {
+                LazyVStack(spacing: 20) {
+                    ForEach(results) { result in
+                        SearchResultRow(
+                            result: result,
+                            isFocused: focusedID == result.id,
+                            listFrame: geometry.frame(in: .global),
+                            iconSpotifyBlack: "spotify_icon_black",
+                            iconSpotifyWhite: "spotify_icon_white",
+                            iconTidalBlack: "tidal_icon_black",
+                            iconTidalWhite: "tidal_icon_white",
+                            iconYTWhite: "yt_icon_white",
+                            iconYTBlack: "yt_icon_black"
+                        )
+                    }
+                }
+                .frame(minHeight: geometry.size.height)
+                .frame(maxWidth: .infinity)
+            }
+        }
+    }
+
+    func updateFocus(with preferences: [String: Double]) {
+        // If any card is > 95% visible, focus it.
+        // If multiple are, pick the first one (or could be all, but "focus" implies singular usually).
+        // My previous logic allowed multiple. Let's stick to singular for "focus" to be cleaner,
+        // or just pick the "most" visible one if none are fully visible.
+        
+        let fullyVisibleThreshold = 0.95
+        let fullyVisibleIDs = preferences.filter { $0.value >= fullyVisibleThreshold }.map { $0.key }
+        
+        if let firstFullyVisible = fullyVisibleIDs.first {
+            focusedID = firstFullyVisible
+        } else {
+            // Fallback to the most visible one
+            if let max = preferences.max(by: { $0.value < $1.value }) {
+                focusedID = max.key
+            } else {
+                focusedID = nil
+            }
         }
     }
 }

--- a/PAMS/Views/SearchResultRow.swift
+++ b/PAMS/Views/SearchResultRow.swift
@@ -2,10 +2,13 @@ import SwiftUI
 import UIKit
 
 struct SearchResultRow: View {
-    @Environment(\.openURL) private var openURL
+    @Environment(\.openURL) var openURL
+    @Environment(\.colorScheme) var colorScheme
 
     let result: SearchResult
-    @Environment(\.colorScheme) private var colorScheme
+    let isFocused: Bool
+    let listFrame: CGRect
+    
     let iconSpotifyBlack: String
     let iconSpotifyWhite: String
     let iconTidalBlack: String
@@ -13,26 +16,15 @@ struct SearchResultRow: View {
     let iconYTWhite: String
     let iconYTBlack: String
 
-    private func open(link: PlatformLink?) {
-        guard let link else { return }
-
-        if let nativeUrlString = link.nativeUrl, let nativeUrl = URL(string: nativeUrlString), UIApplication.shared.canOpenURL(nativeUrl) {
-            openURL(nativeUrl)
-        } else if let webUrlString = link.webUrl, let webUrl = URL(string: webUrlString) {
-            openURL(webUrl)
-        }
-    }
-
     var body: some View {
         VStack(spacing: 12) {
-            ArtworkCard {
-                
+            ArtworkCard(isFocused: isFocused) {
                 if let url = result.artworkURL {
                     AsyncImage(url: url) { phase in
                         switch phase {
                         case .success(let image):
                             image.resizable().scaledToFit()
-                        case .failure(_):
+                        case .failure:
                             Color.secondary.opacity(0.1)
                         case .empty:
                             ProgressView()
@@ -44,19 +36,18 @@ struct SearchResultRow: View {
                     Color.secondary.opacity(0.1)
                 }
             } back: {
-                
                 VStack(alignment: .leading, spacing: 6) {
-                        Text("Release Date: \(result.releaseDate)")
-                        Divider()
-                        Text("Album: \(result.album)")
-                        Divider()
-                        Text("Genre: \(result.genre)")
-                        Divider()
-                        Text("Duration: \(result.duration)")
-                        Divider()
-                        Text("Label: \(result.recordLabel)")
-                        Divider()
-                        Text("© \(result.copyright)")
+                    Text("Release Date: \(result.releaseDate)")
+                    Divider()
+                    Text("Album: \(result.album)")
+                    Divider()
+                    Text("Genre: \(result.genre)")
+                    Divider()
+                    Text("Duration: \(result.duration)")
+                    Divider()
+                    Text("Label: \(result.recordLabel)")
+                    Divider()
+                    Text("© \(result.copyright)")
                 }
                 .font(.caption)
                 .fontWeight(.bold)
@@ -87,14 +78,55 @@ struct SearchResultRow: View {
 
             HStack(spacing: 18) {
                 PlatformButton(icon: .system("applelogo"), size: 44) {
-                    open(link: result.links.apple) }
-                PlatformButton(icon: .asset(colorScheme == .dark ? iconSpotifyWhite : iconSpotifyBlack), size: 44) { open(link: result.links.spotify) }
-                PlatformButton(icon: .asset(colorScheme == .dark ? iconTidalWhite : iconTidalBlack), size: 44) { open(link: result.links.tidal) }
-                PlatformButton(icon: .asset(colorScheme == .dark ? iconYTWhite : iconYTBlack ), size: 44) { open(link: result.links.youtube) }
+                    open(link: result.links.apple)
+                }
+                PlatformButton(icon: .asset(colorScheme == .dark ? iconSpotifyWhite : iconSpotifyBlack), size: 44) {
+                    open(link: result.links.spotify)
+                }
+                PlatformButton(icon: .asset(colorScheme == .dark ? iconTidalWhite : iconTidalBlack), size: 44) {
+                    open(link: result.links.tidal)
+                }
+                PlatformButton(icon: .asset(colorScheme == .dark ? iconYTWhite : iconYTBlack), size: 44) {
+                    open(link: result.links.youtube)
+                }
             }
             .font(.title3)
         }
         .frame(maxWidth: .infinity)
         .padding(.vertical, 20)
+        .background {
+            GeometryReader { geometry in
+                Color.clear
+                    .preference(
+                        key: VisibilityPreferenceKey.self,
+                        value: [result.id: calculateVisibility(geometry: geometry)]
+                    )
+            }
+        }
+    }
+
+    func open(link: PlatformLink?) {
+        guard let link else { return }
+
+        if let nativeUrlString = link.nativeUrl,
+           let nativeUrl = URL(string: nativeUrlString),
+           UIApplication.shared.canOpenURL(nativeUrl) {
+            openURL(nativeUrl)
+        } else if let webUrlString = link.webUrl,
+                  let webUrl = URL(string: webUrlString) {
+            openURL(webUrl)
+        }
+    }
+    
+    func calculateVisibility(geometry: GeometryProxy) -> Double {
+        let frame = geometry.frame(in: .global)
+        let intersection = frame.intersection(listFrame)
+        
+        if intersection.isNull { return 0 }
+        
+        let visibleArea = intersection.width * intersection.height
+        let totalArea = frame.width * frame.height
+        
+        return totalArea > 0 ? Double(visibleArea / totalArea) : 0
     }
 }


### PR DESCRIPTION
artworkcard & visibility:
- only animate the artworkcard when it's fully visible or the most visible item on screen to reduce noise
- switched to a `dashphase` animation for the border so it loops perfectly without that weird jump
- added a smooth fade-in/out for the stroke when focus changes
- implemented a delayed stop mechanism so the animation doesn't snap off abruptly before fading out
- cleaned up the visibility tracking logic using preferencekeys
- fixed some deprecation warnings and compiler timeouts in the perimeter calculation
- general code cleanup and comment refinement to keep things tidy

assets:
- extracted the path data from the `greekkeyshape` component to create a standalone svg file
- created a new `resources` directory to keep assets organized