### PR TITLE
refactor search flow to use actors and parallel fetching

### DIFF
--- a/PAMS/Services/MusicBatchLoader.swift
+++ b/PAMS/Services/MusicBatchLoader.swift
@@ -1,0 +1,127 @@
+import Foundation
+
+actor MusicBatchLoader {
+    func enrich(tracks: [SpotifyTrack], albums: [SpotifyAlbum]) async -> (tracks: [SpotifyTrack], albums: [SpotifyAlbum]) {
+        async let enrichedAlbums = fetchMissingAlbums(for: tracks, existingAlbums: albums)
+        async let enrichedArtists = fetchMissingArtists(for: tracks, albums: albums)
+        
+        let (albumMap, artistMap) = await (enrichedAlbums, enrichedArtists)
+        
+        let finalTracks = tracks.map { track in
+            var updatedTrack = track
+            
+            if let fullAlbum = albumMap[track.album.id] {
+                updatedTrack = SpotifyTrack(
+                    id: track.id,
+                    name: track.name,
+                    artists: track.artists,
+                    album: fullAlbum,
+                    externalIds: track.externalIds,
+                    externalUrls: track.externalUrls,
+                    durationMs: track.durationMs,
+                    popularity: track.popularity
+                )
+            }
+            
+            if let firstArtist = track.artists.first, let fullArtist = artistMap[firstArtist.id] {
+                var newArtists = updatedTrack.artists
+                newArtists[0] = fullArtist
+                updatedTrack = SpotifyTrack(
+                    id: updatedTrack.id,
+                    name: updatedTrack.name,
+                    artists: newArtists,
+                    album: updatedTrack.album,
+                    externalIds: updatedTrack.externalIds,
+                    externalUrls: updatedTrack.externalUrls,
+                    durationMs: updatedTrack.durationMs,
+                    popularity: updatedTrack.popularity
+                )
+            }
+            
+            return updatedTrack
+        }
+        
+        let finalAlbums = albums.map { album in
+            var updatedAlbum = albumMap[album.id] ?? album
+            
+            if let firstArtist = album.artists.first, let fullArtist = artistMap[firstArtist.id] {
+                var newArtists = updatedAlbum.artists
+                newArtists[0] = fullArtist
+                updatedAlbum = SpotifyAlbum(
+                    id: updatedAlbum.id,
+                    name: updatedAlbum.name,
+                    images: updatedAlbum.images,
+                    releaseDate: updatedAlbum.releaseDate,
+                    copyrights: updatedAlbum.copyrights,
+                    label: updatedAlbum.label,
+                    artists: newArtists,
+                    externalUrls: updatedAlbum.externalUrls,
+                    totalTracks: updatedAlbum.totalTracks,
+                    genres: updatedAlbum.genres
+                )
+            }
+            
+            return updatedAlbum
+        }
+        
+        return (finalTracks, finalAlbums)
+    }
+    
+    private func fetchMissingAlbums(for tracks: [SpotifyTrack], existingAlbums: [SpotifyAlbum]) async -> [String: SpotifyAlbum] {
+        let trackAlbumIDs = tracks.map { $0.album.id }
+        let directAlbumIDs = existingAlbums.map { $0.id }
+        let allIDs = Set(trackAlbumIDs + directAlbumIDs)
+        
+        guard !allIDs.isEmpty else { return [:] }
+        
+        let chunks = stride(from: 0, to: allIDs.count, by: 20).map {
+            Array(Array(allIDs)[$0..<min($0 + 20, allIDs.count)])
+        }
+        
+        return await withTaskGroup(of: [SpotifyAlbum].self) { group in
+            for chunk in chunks {
+                group.addTask {
+                    let albums = try? await MusicAPIService.shared.getSpotifyAlbums(ids: chunk)
+                    return albums ?? []
+                }
+            }
+            
+            var results: [String: SpotifyAlbum] = [:]
+            for await albums in group {
+                for album in albums {
+                    results[album.id] = album
+                }
+            }
+            return results
+        }
+    }
+    
+    private func fetchMissingArtists(for tracks: [SpotifyTrack], albums: [SpotifyAlbum]) async -> [String: SpotifyArtist] {
+        let trackArtistIDs = tracks.compactMap { $0.artists.first?.id }
+        let albumArtistIDs = albums.compactMap { $0.artists.first?.id }
+        let allIDs = Set(trackArtistIDs + albumArtistIDs)
+        
+        guard !allIDs.isEmpty else { return [:] }
+        
+        let chunks = stride(from: 0, to: allIDs.count, by: 50).map {
+            Array(Array(allIDs)[$0..<min($0 + 50, allIDs.count)])
+        }
+        
+        return await withTaskGroup(of: [SpotifyArtist].self) { group in
+            for chunk in chunks {
+                group.addTask {
+                    let artists = try? await MusicAPIService.shared.getSpotifyArtists(ids: chunk)
+                    return artists ?? []
+                }
+            }
+            
+            var results: [String: SpotifyArtist] = [:]
+            for await artists in group {
+                for artist in artists {
+                    results[artist.id] = artist
+                }
+            }
+            return results
+        }
+    }
+}

--- a/PAMS/Utils/SearchUtils.swift
+++ b/PAMS/Utils/SearchUtils.swift
@@ -1,6 +1,7 @@
 import Foundation
+import RegexBuilder
 
-class MusicSearchRanker {
+actor MusicSearchRanker {
 
     private let stopWords: Set<String> = ["a", "an", "and", "are", "as", "at", "be", "by", "for", "from", "has", "he", "in", "is", "it", "its", "of", "on", "that", "the", "to", "was", "were", "will", "with"]
 
@@ -35,19 +36,17 @@ class MusicSearchRanker {
     
     init() {}
     
-    enum RankedItem {
-        case track(SpotifyTrack, Double)
-        case album(SpotifyAlbum, Double)
+    struct RankedItem: Sendable {
+        let item: ItemType
+        let score: Double
         
-        var score: Double {
-            switch self {
-            case .track(_, let s): return s
-            case .album(_, let s): return s
-            }
+        enum ItemType: Sendable {
+            case track(SpotifyTrack)
+            case album(SpotifyAlbum)
         }
     }
 
-    struct SearchResult {
+    struct SearchResult: Sendable {
         let items: [RankedItem]
         let hasRelevantResults: Bool
     }
@@ -56,20 +55,18 @@ class MusicSearchRanker {
         let query = processQuery(term: term)
 
         var rankedItems: [RankedItem] = []
-        
 
         for (index, track) in tracks.enumerated() {
             let score = calculateTrackScore(track, query: query, originalIndex: index, totalItems: tracks.count)
             if score > 0 {
-                rankedItems.append(.track(track, score))
+                rankedItems.append(RankedItem(item: .track(track), score: score))
             }
         }
-        
 
         for (index, album) in albums.enumerated() {
             let score = calculateAlbumScore(album, query: query, originalIndex: index, totalItems: albums.count)
             if score > 0 {
-                rankedItems.append(.album(album, score))
+                rankedItems.append(RankedItem(item: .album(album), score: score))
             }
         }
 
@@ -94,7 +91,7 @@ class MusicSearchRanker {
 
     private func calculateTrackScore(_ track: SpotifyTrack, query: ProcessedQuery, originalIndex: Int, totalItems: Int) -> Double {
         let titleTokens = tokenize(track.name)
-        let artistTokens = tokenize(track.artistName)
+        let artistTokens = tokenize(track.artists.map { $0.name }.joined(separator: ", ")) // Avoid artistName if MainActor
         let albumTokens = tokenize(track.album.name)
 
         let titleScore = calculateFieldScore(query: query, fieldTokens: titleTokens)
@@ -136,7 +133,7 @@ class MusicSearchRanker {
 
     private func calculateAlbumScore(_ album: SpotifyAlbum, query: ProcessedQuery, originalIndex: Int, totalItems: Int) -> Double {
         let titleTokens = tokenize(album.name)
-        let artistTokens = tokenize(album.artistName)
+        let artistTokens = tokenize(album.artists.map { $0.name }.joined(separator: ", ")) // Avoid artistName if MainActor
         
         let titleScore = calculateFieldScore(query: query, fieldTokens: titleTokens)
         let artistScore = calculateFieldScore(query: query, fieldTokens: artistTokens)
@@ -157,7 +154,6 @@ class MusicSearchRanker {
              let penalty = pow(0.85, diff) 
              textScore *= penalty
         }
-        
         
         let albumEfficiencyBonus = 0.5
         let rankScore = (1.0 - (Double(originalIndex) / Double(totalItems))) * originalRankWeight
@@ -201,8 +197,13 @@ class MusicSearchRanker {
         var result = string.lowercased()
 
         for (key, value) in synonyms {
-            let pattern = "\\b\(NSRegularExpression.escapedPattern(for: key))\\b"
-            result = result.replacingOccurrences(of: pattern, with: value, options: [.regularExpression, .caseInsensitive])
+            let regex = Regex {
+                Anchor.wordBoundary
+                key
+                Anchor.wordBoundary
+            }.ignoresCase()
+            
+            result = result.replacing(regex, with: value)
         }
 
         result = result.folding(options: .diacriticInsensitive, locale:.current)

--- a/PAMS/ViewModels/SongViewModel.swift
+++ b/PAMS/ViewModels/SongViewModel.swift
@@ -43,6 +43,7 @@ final class SongViewModel: ObservableObject {
     @Published private(set) var status: SearchStatus = .idle 
 
     private let apiService = MusicAPIService.shared
+    private let batchLoader = MusicBatchLoader()
     private let searchRanker = MusicSearchRanker()
     private var searchTask: Task<Void, Never>?
 
@@ -64,101 +65,14 @@ final class SongViewModel: ObservableObject {
         searchTask = Task {
             do {
                 var (spotifyTracks, spotifyAlbums) = try await apiService.searchSpotify(term: trimmed)
-                let trackAlbumIDs = spotifyTracks.map { $0.album.id }
-                let directAlbumIDs = spotifyAlbums.map { $0.id }
-                let allAlbumIDs = Set(trackAlbumIDs + directAlbumIDs)
                 
-                var enrichedAlbumMap: [String: SpotifyAlbum] = [:]
+                guard !Task.isCancelled else { return }
                 
-                if !allAlbumIDs.isEmpty {
-                    let chunks = stride(from: 0, to: allAlbumIDs.count, by: 20).map {
-                        Array(Array(allAlbumIDs)[$0..<min($0 + 20, allAlbumIDs.count)])
-                    }
-                    
-                    for chunk in chunks {
-                        if let fetchedAlbums = try? await apiService.getSpotifyAlbums(ids: chunk) {
-                            for album in fetchedAlbums {
-                                enrichedAlbumMap[album.id] = album
-                            }
-                        }
-                    }
-                                        
-                    spotifyAlbums = spotifyAlbums.map { enrichedAlbumMap[$0.id] ?? $0 }
-                    
-                    spotifyTracks = spotifyTracks.map { track in
-                        if let fullAlbum = enrichedAlbumMap[track.album.id] {
-                            return SpotifyTrack(
-                                id: track.id,
-                                name: track.name,
-                                artists: track.artists,
-                                album: fullAlbum, 
-                                externalIds: track.externalIds,
-                                externalUrls: track.externalUrls,
-                                durationMs: track.durationMs,
-                                popularity: track.popularity
-                            )
-                        } else {
-                            return track
-                        }
-                    }
-                }
+                (spotifyTracks, spotifyAlbums) = await batchLoader.enrich(tracks: spotifyTracks, albums: spotifyAlbums)
                 
-                let artistIDs = Set(spotifyTracks.compactMap { $0.artists.first?.id })
-                var enrichedArtistMap: [String: SpotifyArtist] = [:]
-                
-                if !artistIDs.isEmpty {
-                    let chunks = stride(from: 0, to: artistIDs.count, by: 50).map {
-                        Array(Array(artistIDs)[$0..<min($0 + 50, artistIDs.count)])
-                    }
-                    
-                    for chunk in chunks {
-                        if let fetchedArtists = try? await apiService.getSpotifyArtists(ids: chunk) {
-                            for artist in fetchedArtists {
-                                enrichedArtistMap[artist.id] = artist
-                            }
-                        }
-                    }
-                    
-                    spotifyTracks = spotifyTracks.map { track in
-                        if let firstArtist = track.artists.first, let fullArtist = enrichedArtistMap[firstArtist.id] {
-                            var newArtists = track.artists
-                            newArtists[0] = fullArtist
-                            return SpotifyTrack(
-                                id: track.id,
-                                name: track.name,
-                                artists: newArtists,
-                                album: track.album,
-                                externalIds: track.externalIds,
-                                externalUrls: track.externalUrls,
-                                durationMs: track.durationMs,
-                                popularity: track.popularity
-                            )
-                        }
-                        return track
-                    }
-                    
-                    spotifyAlbums = spotifyAlbums.map { album in
-                        if let firstArtist = album.artists.first, let fullArtist = enrichedArtistMap[firstArtist.id] {
-                           var newArtists = album.artists
-                           newArtists[0] = fullArtist
-                           return SpotifyAlbum(
-                               id: album.id,
-                               name: album.name,
-                               images: album.images,
-                               releaseDate: album.releaseDate,
-                               copyrights: album.copyrights,
-                               label: album.label,
-                               artists: newArtists,
-                               externalUrls: album.externalUrls,
-                               totalTracks: album.totalTracks,
-                               genres: album.genres
-                           )
-                        }
-                        return album
-                    }
-                }
-                
-                let rankedResult = searchRanker.sortAndFilter(tracks: spotifyTracks, albums: spotifyAlbums, term: trimmed)
+                guard !Task.isCancelled else { return }
+
+                let rankedResult = await searchRanker.sortAndFilter(tracks: spotifyTracks, albums: spotifyAlbums, term: trimmed)
                 let rankedItems = rankedResult.items
 
                 guard !Task.isCancelled else { return }
@@ -171,11 +85,11 @@ final class SongViewModel: ObservableObject {
 
                 if let firstRanked = rankedItems.first {
                     let firstResult: SearchResultItem
-                    switch firstRanked {
-                    case .track(let t, _): 
+                    switch firstRanked.item {
+                    case .track(let t): 
                         let p = await self.augmentSpotifyTrack(t)
                         firstResult = .track(p)
-                    case .album(let a, _): 
+                    case .album(let a): 
                         let p = await self.augmentSpotifyAlbum(a)
                         firstResult = .album(p)
                     }
@@ -186,9 +100,9 @@ final class SongViewModel: ObservableObject {
                     let remainingRanked = Array(rankedItems.dropFirst())
                     
                     initialResults.append(contentsOf: remainingRanked.map { item in
-                        switch item {
-                        case .track(let t, _): return .track(self.createPlaceholder(from: t))
-                        case .album(let a, _): return .album(self.createPlaceholder(from: a))
+                        switch item.item {
+                        case .track(let t): return .track(self.createPlaceholder(from: t))
+                        case .album(let a): return .album(self.createPlaceholder(from: a))
                         }
                     })
                     
@@ -198,10 +112,10 @@ final class SongViewModel: ObservableObject {
                     await withTaskGroup(of: SearchResultItem.self, returning: Void.self) { group in
                         for item in remainingRanked {
                             group.addTask {
-                                switch item {
-                                case .track(let t, _): 
+                                switch item.item {
+                                case .track(let t): 
                                     return .track(await self.augmentSpotifyTrack(t))
-                                case .album(let a, _): 
+                                case .album(let a): 
                                     return .album(await self.augmentSpotifyAlbum(a))
                                 }
                             }


### PR DESCRIPTION
added MusicBatchLoader to fetch metadata chunks in parallel via TaskGroup converted MusicSearchRanker to an actor to move ranking math off the main thread stripped the manual enrichment/chunking logic out of SongViewModel updated SearchUtils to use Swift's native RegexBuilder fixed Swift 6 concurrency warnings in the search flow